### PR TITLE
Support terrain hashing, too

### DIFF
--- a/tile-hash-proxy/__init__.py
+++ b/tile-hash-proxy/__init__.py
@@ -50,7 +50,7 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         self.end_headers()
 
         kilobyte = 1024 * 1000
-        chunk_size = 1 * kilobyte
+        chunk_size = 16 * kilobyte
         for chunk in res.iter_content(chunk_size):
             self.wfile.write(chunk)
 

--- a/tile-hash-proxy/__init__.py
+++ b/tile-hash-proxy/__init__.py
@@ -30,7 +30,7 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
     def do_GET(self):
         query_params = self.path.split('?')
-        old_path = query_params.pop()
+        old_path = query_params[0]
         md5_hash = calc_hash(old_path)
         new_path = '%(date)s/%(md5)s%(path)s' % dict(
             date=date_prefix,

--- a/tile-hash-proxy/__init__.py
+++ b/tile-hash-proxy/__init__.py
@@ -1,11 +1,19 @@
 import SimpleHTTPServer
-import BaseHTTPServer
 import SocketServer
 import requests
 import md5
 
 
-def calc_hash(s):
+def calc_hash_terrain(s):
+    # When Ian built the hash for terrain tiles he used the path without
+    # the leading slash and the first 6 chars of the hex digest instead of 5
+    m = md5.new()
+    m.update(s[1:])
+    md5_hash = m.hexdigest()
+    return md5_hash[:6]
+
+
+def calc_hash_vector(s):
     m = md5.new()
     m.update(s)
     md5_hash = m.hexdigest()
@@ -14,6 +22,8 @@ def calc_hash(s):
 
 date_prefix = ''
 base_url = ''
+calc_hash = None
+
 
 class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     server_version = "0.1"
@@ -48,17 +58,39 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-    import sys
+    import argparse
 
-    if len(sys.argv) < 4:
-        print "Usage: tile-hash-proxy/__init__.py port date-prefix base-url"
-        sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'port',
+        type=int,
+        help="Port to listen on")
+    parser.add_argument(
+        'date_prefix',
+        help="Date prefix string to append to the base URL")
+    parser.add_argument(
+        'base_url',
+        help="Base S3 URL to make requests to")
+    parser.add_argument(
+        '--terrain',
+        dest='variant',
+        action='store_const',
+        const='terrain',
+        default='vector',
+        help="Use Terrain tiles variant of hashing")
+    args = parser.parse_args()
 
-    port = int(sys.argv[1])
-    date_prefix = sys.argv[2]
-    base_url = sys.argv[3]
+    date_prefix = args.date_prefix
+    base_url = args.base_url
 
-    httpd = SocketServer.TCPServer(("", port), Handler)
+    if args.variant == 'vector':
+        calc_hash = calc_hash_vector
+    elif args.variant == 'terrain':
+        calc_hash = calc_hash_terrain
+    else:
+        print "Uh oh I don't know how to hash %s" % args.variant
 
-    print "Serving at http://localhost:%d/" % port
+    httpd = SocketServer.TCPServer(("", args.port), Handler)
+
+    print "Serving at http://localhost:%d/" % args.port
     httpd.serve_forever()


### PR DESCRIPTION
When I wrote the hashing algorithm for the latest terrain rendering code I ended up using a slightly different variant of the hashing that we do for vector.

https://github.com/mojodna/marblecutter/blob/6ce925b16683c97213c9718c85ede8fc17c661bc/examples/render_pyramid.py#L88-L106

This PR adds support for that variant and switches to using `argparse` to help along the way.